### PR TITLE
Hide points when they have not been loaded

### DIFF
--- a/common/sonar.js
+++ b/common/sonar.js
@@ -11,11 +11,20 @@ function sonarStatusReferesher() {
 
     var rnd = Math.round(Math.random() * 1000000000000);
     var marker = pointURI.indexOf("&rnd=");
+    var wasPointRefreshedEarlier = marker !== -1
 
-    if (marker == -1) {
-      point.src = point.src + "&rnd=" + rnd.toString(26);
-    } else {
+    if (wasPointRefreshedEarlier) {
       point.src = point.src.substr(0, marker) + "&rnd=" + rnd.toString(26);
+    } else {
+      point.addEventListener("error", function() {
+        this.style.visibility = "hidden";
+      });
+
+      point.addEventListener("load", function() {
+        this.style.visibility = "visible";
+      });
+      
+      point.src = point.src + "&rnd=" + rnd.toString(26);
     }
   }
 }


### PR DESCRIPTION
### What did you implement:

Hiding points in case of non loading, which may be the problem when the points are auto refreshed with turned off Internet/VPN connection.

### How did you implement it:

I've improved a bit the script that refreshes the points.

### How can we verify it:

🤔 

1. Copy the script from this PR.
2. Paste it into DevTools of a page of the Jira instance that already has Sonar installed. The page should have Sonar points somewhere on it.
3. Run `sonarStatusReferesher()`. It should be the first run of this function there. Which means that the page should be refreshed before the testing.
4. Broke any Sonar point by changing its `src` attribute manually. The point should be hidden.
5. Restore the original `src` value (e.g. press Ctrl+Z). The point should be visible.

### TODO's:

- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

I've checked only those TODOs that are applicable here.

**Is this ready for review?:** Yes
**Is it a breaking change?:** No
